### PR TITLE
fix: Following "next" URL after login.

### DIFF
--- a/flask_appbuilder/security/views.py
+++ b/flask_appbuilder/security/views.py
@@ -532,7 +532,8 @@ class AuthLDAPView(AuthView):
                 flash(as_unicode(self.invalid_login_message), "warning")
                 return redirect(self.appbuilder.get_url_for_login)
             login_user(user, remember=False)
-            return redirect(self.appbuilder.get_url_for_index)
+            next_url = request.args.get("next")
+            return redirect(next_url or self.appbuilder.get_url_for_index)
         return self.render_template(
             self.login_template, title=self.title, form=form, appbuilder=self.appbuilder
         )


### PR DESCRIPTION



<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

The `has_access` decorator provides a "next" parameter when redirecting to this endpoint.
https://github.com/suiting-young/Flask-AppBuilder/blob/b9b3259a9d47a14430144c8362215c2143f06aa4/flask_appbuilder/security/decorators.py#L117-L122
Should try to redirect back here if login succeeded.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [x] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
